### PR TITLE
Remove async await from routes

### DIFF
--- a/src/server/dao.ts
+++ b/src/server/dao.ts
@@ -14,23 +14,39 @@ export class Dao {
         await this.client.connect();
     }
 
-    public async getUsers(req, res) {
-        const { rows } = await this.client.query('SELECT * FROM users');
-        res.send(rows);
+    public getUsers(req, res) {
+        this.client.query('SELECT * FROM users', (err, results) => {
+            if (err) {
+                throw err;
+            }
+            res.send(results.rows);
+        });
     }
 
-    public async getTeams(req, res) {
-        const { rows } = await this.client.query('SELECT * FROM teams');
-        res.send(rows);
+    public getTeams(req, res) {
+        this.client.query('SELECT * FROM teams', (err, results) => {
+            if (err) {
+                throw err;
+            }
+            res.send(results.rows);
+        });
     }
 
-    public async getSinglesGames(req, res) {
-        const { rows } = await this.client.query('SELECT * FROM singles_games');
-        res.send(rows);
+    public getSinglesGames(req, res) {
+        this.client.query('SELECT * FROM singles_games', (err, results) => {
+            if (err) {
+                throw err;
+            }
+            res.send(results.rows);
+        });
     }
 
-    public async getDoublesGames(req, res) {
-        const { rows } = await this.client.query('SELECT * FROM doubles_games');
-        res.send(rows);
+    public getDoublesGames(req, res) {
+        this.client.query('SELECT * FROM doubles_games', (err, results) => {
+            if (err) {
+                throw err;
+            }
+            res.send(results.rows);
+        });
     }
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -29,19 +29,27 @@ if (process.env.NODE_ENV === 'production') {
 app.use(express.static(path.join(__dirname + '/public')));
 
 // Return all USERS
-app.get('/api/users', dao.getUsers);
+app.get('/api/users', (req, res) => {
+    dao.getUsers(req, res);
+});
 
 
 // Return all TEAMS
-app.get('/api/teams', dao.getTeams);
+app.get('/api/teams', (req, res) => {
+    dao.getTeams(req, res);
+});
 
 
 // Return all SINGLES GAMES
-app.get('/api/singles_games', dao.getSinglesGames);
+app.get('/api/singles_games', (req, res) => {
+    dao.getSinglesGames(req, res);
+});
 
 
 // Return all DOUBLES GAMES
-app.get('/api/doubles_games', dao.getDoublesGames);
+app.get('/api/doubles_games', (req, res) => {
+    dao.getDoublesGames(req, res);
+});
 
 
 // For all GET requests, send back index.html so that PathLocationStrategy can be used


### PR DESCRIPTION
This only removes the async await statements from the Express routes, which Express doesn't handle without adding a middleware.