### PR TITLE
Database Pooling and modularize DAO routing

### DIFF
--- a/src/server/dao/base-dao.ts
+++ b/src/server/dao/base-dao.ts
@@ -1,15 +1,52 @@
 import { Response, Request, NextFunction, Router } from 'express';
 import { Pool } from 'pg';
 
+/**
+ * Base class to be used by all DAO which provides the default implementation
+ * and structure for making CRUD operations.
+ *
+ * This is an abstract class and must be subclassed in order to provide a concrete implementation.
+ */
 export abstract class BaseDao {
+
+    /**
+     * The router used by the DAO to forward routes to specific functions.
+     *
+     * @public
+     * @type {Router}
+     */
     public router = Router();
 
+    /**
+     * The base table this DAO uses.
+     *
+     * @protected
+     * @return {string}
+     */
     protected abstract get defaultTableName(): string;
 
+    /**
+     * Constructs a new instance of this DAO and assigns the global PG.Pool to it.
+     * It then sets up all of it's routes.
+     *
+     * @public
+     * @param {Pool} pool - The global PG.Pool to use for making DB queries
+     */
     constructor(protected pool: Pool) {
         this.setupRoutes();
     }
 
+    /**
+     * Property to retrieve this DAO's GET request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * This is the default implementation which just retrieves a single entity by ID from
+     * the DAO's default table when called with an <id> request param or returns all entities
+     * and rows from the default table.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get get() {
         return async (request: Request, response: Response, next: NextFunction) => {
             if (request.params.id) {
@@ -24,12 +61,45 @@ export abstract class BaseDao {
         };
     }
 
-    public abstract get put(): (request: Request, response: Response, next: NextFunction) => any;
+    /**
+     * Property to retrieve this DAO's PUT request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * This is an abstract property and must be implemented in a subclass.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
+    public abstract get put(): (request: Request, response: Response, next: NextFunction) => Promise<any>;
 
-    public abstract get post(): (request: Request, response: Response, next: NextFunction) => any;
+    /**
+     * Property to retrieve this DAO's POST request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * This is an abstract property and must be implemented in a subclass.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
+    public abstract get post(): (request: Request, response: Response, next: NextFunction) => Promise<any>;
 
-    public abstract get delete(): (request: Request, response: Response, next: NextFunction) => any;
+    /**
+     * Property to retrieve this DAO's DELETE request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * This is an abstract property and must be implemented in a subclass.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
+    public abstract get delete(): (request: Request, response: Response, next: NextFunction) => Promise<any>;
 
+    /**
+     * Sets up the nested routes in this DAO and assigns them to the Router.
+     *
+     * @protected
+     * @return {void}
+     */
     protected setupRoutes(): void {
         this.router.route('/').get(this.get).post(this.post);
         this.router.route('/:id').get(this.get).put(this.put).delete(this.delete);

--- a/src/server/dao/base-dao.ts
+++ b/src/server/dao/base-dao.ts
@@ -1,0 +1,37 @@
+import { Response, Request, NextFunction, Router } from 'express';
+import { Pool } from 'pg';
+
+export abstract class BaseDao {
+    public router = Router();
+
+    protected abstract get defaultTableName(): string;
+
+    constructor(protected pool: Pool) {
+        this.setupRoutes();
+    }
+
+    public get get() {
+        return async (request: Request, response: Response, next: NextFunction) => {
+            if (request.params.id) {
+                return this.pool.query(`SELECT * FROM ${this.defaultTableName} WHERE id = $1`, [request.params.id])
+                    .then((results) => response.send(results.rows))
+                    .catch(error => response.send({ error }));
+            } else {
+                return this.pool.query(`SELECT * FROM ${this.defaultTableName}`)
+                    .then((results) => response.send(results.rows))
+                    .catch(error => response.send({ error }));
+            }
+        };
+    }
+
+    public abstract get put(): (request: Request, response: Response, next: NextFunction) => any;
+
+    public abstract get post(): (request: Request, response: Response, next: NextFunction) => any;
+
+    public abstract get delete(): (request: Request, response: Response, next: NextFunction) => any;
+
+    protected setupRoutes(): void {
+        this.router.route('/').get(this.get).post(this.post);
+        this.router.route('/:id').get(this.get).put(this.put).delete(this.delete);
+    }
+}

--- a/src/server/dao/doublesGamesDao.ts
+++ b/src/server/dao/doublesGamesDao.ts
@@ -2,23 +2,55 @@ import { Response, Request, NextFunction, Router } from 'express';
 import { Client } from 'pg';
 import { BaseDao } from './base-dao';
 
+/**
+ * Concrete implementation of the BaseDoa class which provides access to the Doubles
+ * Games DB table.
+ */
 export class DoublesGamesDao extends BaseDao {
+
+    /**
+     * The base table this DAO uses.
+     *
+     * @protected
+     * @return {string}
+     */
     protected get defaultTableName() {
         return 'doubles_games';
     }
 
+    /**
+     * Property to retrieve this DAO's PUT request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get put() {
         return async (request: Request, response: Response, next: NextFunction) => {
             response.send({ error: 'Not implemented yet.' });
         };
     }
 
+    /**
+     * Property to retrieve this DAO's POST request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get post() {
         return async (request: Request, response: Response, next: NextFunction) => {
             response.send({ error: 'Not implemented yet.' });
         };
     }
 
+    /**
+     * Property to retrieve this DAO's DELETE request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get delete() {
         return async (request: Request, response: Response, next: NextFunction) => {
             response.send({ error: 'Not implemented yet.' });

--- a/src/server/dao/doublesGamesDao.ts
+++ b/src/server/dao/doublesGamesDao.ts
@@ -1,30 +1,27 @@
+import { Response, Request, NextFunction, Router } from 'express';
 import { Client } from 'pg';
+import { BaseDao } from './base-dao';
 
-export interface DaoConfig {
-    connectionString: string;
-    ssl: boolean;
-}
-
-export class DoublesGamesDao {
-    private client: Client;
-
-    constructor(private config: DaoConfig) {
-        this.client = new Client(config);
-        this.connect().catch(error => {
-            console.log(error);
-        });
+export class DoublesGamesDao extends BaseDao {
+    protected get defaultTableName() {
+        return 'doubles_games';
     }
 
-    public async connect() {
-        await this.client.connect();
+    public get put() {
+        return async (request: Request, response: Response, next: NextFunction) => {
+            response.send({ error: 'Not implemented yet.' });
+        };
     }
 
-    public getDoublesGames(req, res) {
-        this.client.query('SELECT * FROM doubles_games', (err, results) => {
-            if (err) {
-                throw err;
-            }
-            res.send(results.rows);
-        });
+    public get post() {
+        return async (request: Request, response: Response, next: NextFunction) => {
+            response.send({ error: 'Not implemented yet.' });
+        };
+    }
+
+    public get delete() {
+        return async (request: Request, response: Response, next: NextFunction) => {
+            response.send({ error: 'Not implemented yet.' });
+        };
     }
 }

--- a/src/server/dao/index.ts
+++ b/src/server/dao/index.ts
@@ -31,9 +31,7 @@ function setupTeams(app: Express, pool: Pool) {
     app.use(`${BASE_URL}/teams`, teamsDao.router);
 
     // Set up deprecated route
-    app.post(`${BASE_URL}/create_team`, (request: Request, response: Response) => {
-        response.redirect(`${BASE_URL}/users`);
-    });
+    app.post(`${BASE_URL}/create_team`, teamsDao.post);
 }
 
 function setupUsers(app: Express, pool: Pool) {
@@ -41,9 +39,7 @@ function setupUsers(app: Express, pool: Pool) {
     app.use(`${BASE_URL}/users`, usersDao.router);
 
     // Set up deprecated route
-    app.post(`${BASE_URL}/create_user`, (request: Request, response: Response) => {
-        response.redirect(`${BASE_URL}/users`);
-    });
+    app.post(`${BASE_URL}/create_user`, usersDao.post);
 }
 
 function setupDefault(app: Express) {

--- a/src/server/dao/index.ts
+++ b/src/server/dao/index.ts
@@ -1,0 +1,44 @@
+import { Express, Router, Request, Response } from 'express';
+import * as path from 'path';
+import { Pool } from 'pg';
+import { UsersDao } from './usersDao';
+import { TeamsDao } from './teamsDao';
+import { SinglesGamesDao } from './singlesGamesDao';
+import { DoublesGamesDao } from './doublesGamesDao';
+
+const BASE_URL = '/api';
+
+export function setupRoutes(app: Express, pool: Pool) {
+    setupSinglesGames(app, pool);
+    setupDoublesGames(app, pool);
+    setupTeams(app, pool);
+    setupUsers(app, pool);
+    setupDefault(app);
+}
+
+function setupSinglesGames(app: Express, pool: Pool) {
+    const singlesGamesDao = new SinglesGamesDao(pool);
+    app.use(`${BASE_URL}/singles_games`, singlesGamesDao.router);
+}
+
+function setupDoublesGames(app: Express, pool: Pool) {
+    const doublesGamesDao = new DoublesGamesDao(pool);
+    app.use(`${BASE_URL}/doubles_games`, doublesGamesDao.router);
+}
+
+function setupTeams(app: Express, pool: Pool) {
+    const teamsDao = new TeamsDao(pool);
+    app.use(`${BASE_URL}/teams`, teamsDao.router);
+}
+
+function setupUsers(app: Express, pool: Pool) {
+    const usersDao = new UsersDao(pool);
+    app.use(`${BASE_URL}/users`, usersDao.router);
+}
+
+function setupDefault(app: Express) {
+    // For all other GET requests, send back index.html
+    app.get('*', (req, res) => {
+        res.sendFile(path.join(__dirname, '../public/index.html'));
+    });
+}

--- a/src/server/dao/index.ts
+++ b/src/server/dao/index.ts
@@ -29,11 +29,21 @@ function setupDoublesGames(app: Express, pool: Pool) {
 function setupTeams(app: Express, pool: Pool) {
     const teamsDao = new TeamsDao(pool);
     app.use(`${BASE_URL}/teams`, teamsDao.router);
+
+    // Set up deprecated route
+    app.post(`${BASE_URL}/create_team`, (request: Request, response: Response) => {
+        response.redirect(`${BASE_URL}/users`);
+    });
 }
 
 function setupUsers(app: Express, pool: Pool) {
     const usersDao = new UsersDao(pool);
     app.use(`${BASE_URL}/users`, usersDao.router);
+
+    // Set up deprecated route
+    app.post(`${BASE_URL}/create_user`, (request: Request, response: Response) => {
+        response.redirect(`${BASE_URL}/users`);
+    });
 }
 
 function setupDefault(app: Express) {

--- a/src/server/dao/singlesGamesDao.ts
+++ b/src/server/dao/singlesGamesDao.ts
@@ -2,23 +2,55 @@ import { Response, Request, NextFunction, Router } from 'express';
 import { Client } from 'pg';
 import { BaseDao } from './base-dao';
 
+/**
+ * Concrete implementation of the BaseDoa class which provides access to the Singles
+ * Games DB table.
+ */
 export class SinglesGamesDao extends BaseDao {
+
+    /**
+     * The base table this DAO uses.
+     *
+     * @protected
+     * @return {string}
+     */
     protected get defaultTableName() {
         return 'singles_games';
     }
 
+    /**
+     * Property to retrieve this DAO's PUT request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get put() {
         return async (request: Request, response: Response, next: NextFunction) => {
             response.send({ error: 'Not implemented yet.' });
         };
     }
 
+    /**
+     * Property to retrieve this DAO's POST request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get post() {
         return async (request: Request, response: Response, next: NextFunction) => {
             response.send({ error: 'Not implemented yet.' });
         };
     }
 
+    /**
+     * Property to retrieve this DAO's DELETE request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get delete() {
         return async (request: Request, response: Response, next: NextFunction) => {
             response.send({ error: 'Not implemented yet.' });

--- a/src/server/dao/singlesGamesDao.ts
+++ b/src/server/dao/singlesGamesDao.ts
@@ -1,30 +1,27 @@
+import { Response, Request, NextFunction, Router } from 'express';
 import { Client } from 'pg';
+import { BaseDao } from './base-dao';
 
-export interface DaoConfig {
-    connectionString: string;
-    ssl: boolean;
-}
-
-export class SinglesGamesDao {
-    private client: Client;
-
-    constructor(private config: DaoConfig) {
-        this.client = new Client(config);
-        this.connect().catch(error => {
-            console.log(error);
-        });
+export class SinglesGamesDao extends BaseDao {
+    protected get defaultTableName() {
+        return 'singles_games';
     }
 
-    public async connect() {
-        await this.client.connect();
+    public get put() {
+        return async (request: Request, response: Response, next: NextFunction) => {
+            response.send({ error: 'Not implemented yet.' });
+        };
     }
 
-    public getSinglesGames(req, res) {
-        this.client.query('SELECT * FROM singles_games', (err, results) => {
-            if (err) {
-                throw err;
-            }
-            res.send(results.rows);
-        });
+    public get post() {
+        return async (request: Request, response: Response, next: NextFunction) => {
+            response.send({ error: 'Not implemented yet.' });
+        };
+    }
+
+    public get delete() {
+        return async (request: Request, response: Response, next: NextFunction) => {
+            response.send({ error: 'Not implemented yet.' });
+        };
     }
 }

--- a/src/server/dao/teamsDao.ts
+++ b/src/server/dao/teamsDao.ts
@@ -2,12 +2,29 @@ import { Response, Request, NextFunction, Router } from 'express';
 import { Client } from 'pg';
 import { BaseDao } from './base-dao';
 
+/**
+ * Concrete implementation of the BaseDoa class which provides access to the Teams
+ * DB table.
+ */
 export class TeamsDao extends BaseDao {
 
+    /**
+     * The base table this DAO uses.
+     *
+     * @protected
+     * @return {string}
+     */
     protected get defaultTableName() {
         return 'teams';
     }
 
+    /**
+     * Property to retrieve this DAO's POST request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get post() {
         return async (request: Request, response: Response, next: NextFunction) => {
             const { team_name, team_slogan, member_one, member_two } = request.body;
@@ -24,18 +41,38 @@ export class TeamsDao extends BaseDao {
         };
     }
 
+    /**
+     * Property to retrieve this DAO's PUT request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get put() {
         return async (request: Request, response: Response, next: NextFunction) => {
             response.send({ error: 'Not implemented yet.' });
         };
     }
 
+    /**
+     * Property to retrieve this DAO's DELETE request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get delete() {
         return async (request: Request, response: Response, next: NextFunction) => {
             response.send({ error: 'Not implemented yet.' });
         };
     }
 
+    /**
+     * Sets up the nested routes in this DAO and assigns them to the Router.
+     *
+     * @protected
+     * @return {void}
+     */
     protected setupRoutes(): void {
         super.setupRoutes();
         // Deprecated, kept for backwards compatibility

--- a/src/server/dao/teamsDao.ts
+++ b/src/server/dao/teamsDao.ts
@@ -66,16 +66,4 @@ export class TeamsDao extends BaseDao {
             response.send({ error: 'Not implemented yet.' });
         };
     }
-
-    /**
-     * Sets up the nested routes in this DAO and assigns them to the Router.
-     *
-     * @protected
-     * @return {void}
-     */
-    protected setupRoutes(): void {
-        super.setupRoutes();
-        // Deprecated, kept for backwards compatibility
-        this.router.route('/create_team').post(this.post);
-    }
 }

--- a/src/server/dao/usersDao.ts
+++ b/src/server/dao/usersDao.ts
@@ -66,16 +66,4 @@ export class UsersDao extends BaseDao {
             response.send({ error: 'Not implemented yet.' });
         };
     }
-
-    /**
-     * Sets up the nested routes in this DAO and assigns them to the Router.
-     *
-     * @protected
-     * @return {void}
-     */
-    protected setupRoutes(): void {
-        super.setupRoutes();
-        // Deprecated, kept for backwards compatibility
-        this.router.route('/create_user').post(this.post);
-    }
 }

--- a/src/server/dao/usersDao.ts
+++ b/src/server/dao/usersDao.ts
@@ -2,12 +2,29 @@ import { Response, Request, NextFunction, Router } from 'express';
 import { Client } from 'pg';
 import { BaseDao } from './base-dao';
 
+/**
+ * Concrete implementation of the BaseDoa class which provides access to the Users
+ * DB table.
+ */
 export class UsersDao extends BaseDao {
 
+    /**
+     * The base table this DAO uses.
+     *
+     * @protected
+     * @return {string}
+     */
     protected get defaultTableName() {
         return 'users';
     }
 
+    /**
+     * Property to retrieve this DAO's POST request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get post() {
         return async (request: Request, response: Response, next: NextFunction) => {
             const { display_name, first_name, last_name, password } = request.body;
@@ -24,18 +41,38 @@ export class UsersDao extends BaseDao {
         };
     }
 
+    /**
+     * Property to retrieve this DAO's PUT request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get put() {
         return async (request: Request, response: Response, next: NextFunction) => {
             response.send({ error: 'Not implemented yet.' });
         };
     }
 
+    /**
+     * Property to retrieve this DAO's DELETE request implementation. It returns a function
+     * which takes the Express Route params and returns a Promise.
+     *
+     * @public
+     * @return {(request: , response: , next: ) => Promise<any>}
+     */
     public get delete() {
         return async (request: Request, response: Response, next: NextFunction) => {
             response.send({ error: 'Not implemented yet.' });
         };
     }
 
+    /**
+     * Sets up the nested routes in this DAO and assigns them to the Router.
+     *
+     * @protected
+     * @return {void}
+     */
     protected setupRoutes(): void {
         super.setupRoutes();
         // Deprecated, kept for backwards compatibility

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -38,6 +38,7 @@ app.use(express.static(path.join(__dirname + '/public')));
 app.use(bodyParser.urlencoded({ extended: true })); // parse application/x-www-form-urlencoded
 app.use(bodyParser.json());
 
+// Setup all routes
 setupRoutes(app, pool);
 
 // Start the app by listening on the default Heroku port


### PR DESCRIPTION
**Changelog**
- Introduces PG db pooling instead of managing multiple clients connected to the DB.
- Makes a base abstract DAO class which the other DAO implement.
- Each DAO now has its own Express.Router to modularize the routing and can handle any sub route it receives. Each acts as if it's the base route so that they can't collide.
- Base DAO implements the default get request which any subclass can override if necessary.
- Deprecates the `/create_team` and `/create_user` routes and favors the POST method of the corresponding DAO. (i.e. `/create_team` calls TeamsDao.post()) Currently, both POST `/api/teams` and POST `/api/create_team` call the same function.

Most of the request methods have not been implemented yet, they just have placeholders for now.

So now, the routes follow this pattern:
- To get all teams you would call GET `/api/teams`
- To get an individual team you would call GET `/api/teams/[:id]`
- To create a team you would call POST `/api/teams`
- To update a team you would call PUT `/api/teams/[:id]`
- To delete a team you would call DELETE `/api/teams/[:id]`